### PR TITLE
rename param variable

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,7 +14,7 @@ WriteMakefile(
   VERSION_FROM => 'lib/LaTeXML/Plugin/LtxMojo.pm',
   PREREQ_PM => {
     'LaTeXML' => '0.8.0',
-    'Mojolicious' => '5.0',
+    'Mojolicious' => '6.0',
     'Archive::Zip' => 0,
     'IO::String' => 0
   },

--- a/lib/LaTeXML/Plugin/LtxMojo.pm
+++ b/lib/LaTeXML/Plugin/LtxMojo.pm
@@ -119,8 +119,8 @@ $app->helper(convert_zip => sub {
 $app->helper(convert_string => sub {
   my ($self) = @_;  
   my ($source,$is_jsonp);
-  my $get_params = $self->req->url->query->params || [];
-  my $post_params = $self->req->body_params->params || [];
+  my $get_params = $self->req->url->query->pairs || [];
+  my $post_params = $self->req->body_params->pairs || [];
   if (scalar(@$post_params) == 1) {
     $source = $post_params->[0];
     $post_params=[];


### PR DESCRIPTION
In line with [recent changes in upstream](https://github.com/kraih/mojo/blob/master/Changes),

> 6.0 2015-02-26 [...]
>  - Renamed params method in Mojo::Parameters to pairs.

`./lib/LaTeXML/Plugin/LtxMojo.pm` needs a small change.